### PR TITLE
Fix vercel.json: use refined rewrite pattern to exclude static files from SPA routing

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -11,7 +11,7 @@
   ],
   "rewrites": [
     {
-      "source": "/(.*)",
+      "source": "/((?!.*\\.(?:js|css|png|jpg|jpeg|svg|ico|json|txt|map|woff2?|ttf|eot|otf)).*)",
       "destination": "/index.html"
     }
   ],


### PR DESCRIPTION
# Fix vercel.json: use refined rewrite pattern to exclude static files from SPA routing

## Summary

This PR fixes a critical production issue where admin, register, dashboard, and browse-services pages were showing blank screens. The root cause was an overly broad Vercel rewrite pattern `/(.*)`  that was incorrectly serving `index.html` for static files like `manifest.json`, causing MIME type mismatches and preventing React from loading on specific routes.

**Key Change:**
- Updated `vercel.json` rewrite pattern from `/(.*)`  to `/((?!.*\\.(?:js|css|png|jpg|jpeg|svg|ico|json|txt|map|woff2?|ttf|eot|otf)).*)`
- This refined pattern excludes static file extensions while preserving SPA routing for actual application routes

**Impact:**
- ✅ Static files (manifest.json, favicon.ico, etc.) now serve with correct MIME types
- ✅ SPA routes continue to work for React application pages  
- ✅ Eliminates browser console errors about syntax errors in manifest.json
- ✅ Fixes blank page issues on /admin, /register, /dashboard, /browse-services

## Review & Testing Checklist for Human

**🔴 HIGH PRIORITY (3 items)**
- [ ] **Test static file serving**: Navigate to `https://fetchwork.vercel.app/manifest.json` and verify it returns JSON with `Content-Type: application/json` (not HTML)
- [ ] **Test affected routes**: Visit `/admin`, `/register`, `/dashboard`, `/browse-services` and confirm React loads properly (no blank screens)
- [ ] **Check browser console**: Ensure no MIME type errors or "Manifest: Line: 1, column: 1, Syntax error" messages appear

**Recommended Test Plan:**
1. Open browser DevTools → Network tab
2. Visit each affected route and verify `index.html` is served (not 404)
3. Check that static assets (favicon.ico, logo192.png, etc.) return proper file types
4. Test a fake route like `/some/nonexistent/path` to ensure SPA fallback still works
5. Clear browser cache and test again to avoid cached responses

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    VJ["vercel.json<br/>(Vercel config)"]:::major-edit
    
    SR1["/admin route"]:::context
    SR2["/register route"]:::context  
    SR3["/dashboard route"]:::context
    
    SF1["manifest.json"]:::context
    SF2["favicon.ico"]:::context
    SF3["*.js, *.css files"]:::context
    
    IH["index.html<br/>(SPA entry point)"]:::context
    
    VJ -->|"NEW: excludes static files"| SF1
    VJ -->|"NEW: excludes static files"| SF2 
    VJ -->|"NEW: excludes static files"| SF3
    
    VJ -->|"UNCHANGED: rewrites to"| IH
    SR1 --> IH
    SR2 --> IH
    SR3 --> IH
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

- **Session Info**: Requested by Chaz (@stancp327) | [Link to Devin run](https://app.devin.ai/sessions/72becd39c20f48e8a6466a34fb0cc354)
- **Regex Pattern**: The new pattern uses negative lookahead `(?!.*\\.)` to exclude files with specific extensions - this is complex but necessary for precise static file exclusion
- **Production Impact**: This fixes a user-facing issue where key application pages were completely inaccessible
- **Browser Caching**: Users may need to hard refresh (Ctrl+F5) to see the fix due to browser caching of the previous broken responses
- **Testing Note**: Local builds with `npx serve dist` worked correctly, confirming this was specifically a Vercel deployment configuration issue