### PR TITLE
URGENT: Fix manifest.json MIME type causing blank pages in production

### DIFF
--- a/client/vercel.json
+++ b/client/vercel.json
@@ -1,6 +1,13 @@
 {
-  "routes": [
-    { "handle": "filesystem" },
-    { "src": "/.*", "dest": "/index.html" }
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/index.html" }
+  ],
+  "headers": [
+    {
+      "source": "/manifest.json",
+      "headers": [
+        { "key": "Content-Type", "value": "application/manifest+json" }
+      ]
+    }
   ]
 }


### PR DESCRIPTION
# URGENT: Fix manifest.json MIME type causing blank pages in production

## Summary

This PR addresses a critical production issue where `manifest.json` is being served as HTML (`text/html; charset=utf-8`) instead of JSON, causing a "Manifest: Line: 1, column: 1, Syntax error" that prevents the React app from loading properly. Protected routes (`/admin`, `/register`, `/browse-services`) display completely blank pages as a result.

**Root Cause**: The current `vercel.json` uses a "routes" configuration that incorrectly routes static assets through the SPA fallback, causing `manifest.json` to return the `index.html` content instead of the actual JSON manifest.

**Solution**: Replace the "routes" configuration with "rewrites" and add explicit headers to ensure `manifest.json` is served with the correct `application/manifest+json` MIME type.

## Review & Testing Checklist for Human

- [ ] **Verify manifest.json MIME type fix** - Check that `https://fetchwork.vercel.app/manifest.json` now serves proper JSON with `application/manifest+json` content type (use browser Network tab or `curl -I`)
- [ ] **Test all previously blank protected routes** - Navigate to `/admin`, `/register`, `/browse-services` and verify they render React components instead of blank pages
- [ ] **Check for regressions on working routes** - Ensure homepage (`/`), login (`/login`), and other public routes continue to function correctly
- [ ] **Monitor browser console** - Verify the "Manifest: Line: 1, column: 1, Syntax error" is resolved and authentication debugging logs appear on protected routes

**Recommended Test Plan**: After deployment, systematically test each route type and use browser developer tools to verify both the manifest.json MIME type and absence of console errors.

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    VercelConfig["client/vercel.json<br/>Deployment Routing"]:::major-edit
    ManifestFile["client/public/manifest.json<br/>PWA Manifest"]:::context
    ReactApp["React App<br/>Frontend Application"]:::context
    
    VercelConfig --> StaticAssets["Static Asset Handling<br/>(manifest.json, favicon.ico)"]:::context
    VercelConfig --> SPARouting["SPA Route Fallback<br/>(/admin, /register, etc.)"]:::context
    ManifestFile --> ReactApp
    StaticAssets --> ManifestFile
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit
        L3[Context/No Edit]:::context
    end

    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

**Critical Fix**: This replaces the problematic "routes" configuration that was causing static assets to be incorrectly routed through the SPA fallback. The curl command confirmed `manifest.json` was returning `content-type: text/html; charset=utf-8` and `filename="index.html"` even after PR #41 was merged.


**Deployment Dependency**: This fix can only be validated in production since the issue is specific to Vercel's routing behavior. Local testing with `npx serve` works correctly.

**Previous Context**: Multiple attempts in PR #41 to fix this issue with regex patterns failed due to Vercel's "invalid-route-source-pattern" errors. This simplified approach using basic rewrites with explicit headers should be more reliable.

---

**Session Details**: 
- Requested by: Chaz (@stancp327)
- Link to Devin run: https://app.devin.ai/sessions/7017a92d84e44adba34de27d675282e5