### PR TITLE
feat: Add user type selection to registration and admin permission management

### DIFF
--- a/client/src/components/Admin/AdminDashboard.css
+++ b/client/src/components/Admin/AdminDashboard.css
@@ -416,6 +416,30 @@
   background: #218838;
 }
 
+.action-buttons {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.action-btn.promote {
+  background-color: #28a745;
+  color: white;
+}
+
+.action-btn.promote:hover {
+  background-color: #218838;
+}
+
+.action-btn.demote {
+  background-color: #ffc107;
+  color: #212529;
+}
+
+.action-btn.demote:hover {
+  background-color: #e0a800;
+}
+
 .action-btn.cancel {
   background: #dc3545;
   color: white;

--- a/client/src/components/Admin/AdminDashboard.js
+++ b/client/src/components/Admin/AdminDashboard.js
@@ -189,6 +189,32 @@ const AdminDashboard = () => {
     }
   };
 
+  const promoteUser = async (userId) => {
+    try {
+      const response = await axios.put(`${apiBaseUrl}/api/admin/users/${userId}/promote`);
+      if (response.data) {
+        alert('User promoted to admin successfully');
+        fetchUsersData();
+      }
+    } catch (error) {
+      console.error('Error promoting user:', error);
+      alert('Failed to promote user: ' + (error.response?.data?.error || 'Unknown error'));
+    }
+  };
+
+  const demoteUser = async (userId) => {
+    try {
+      const response = await axios.put(`${apiBaseUrl}/api/admin/users/${userId}/demote`);
+      if (response.data) {
+        alert('User demoted from admin successfully');
+        fetchUsersData();
+      }
+    } catch (error) {
+      console.error('Error demoting user:', error);
+      alert('Failed to demote user: ' + (error.response?.data?.error || 'Unknown error'));
+    }
+  };
+
   if (loading) {
     return (
       <div className="admin-dashboard">
@@ -392,24 +418,41 @@ const AdminDashboard = () => {
                           </td>
                           <td>{new Date(user.createdAt).toLocaleDateString()}</td>
                           <td>
-                            {user.isSuspended ? (
-                              <button
-                                className="action-btn unsuspend"
-                                onClick={() => unsuspendUser(user._id)}
-                              >
-                                Unsuspend
-                              </button>
-                            ) : (
-                              <button
-                                className="action-btn suspend"
-                                onClick={() => {
-                                  const reason = prompt('Reason for suspension:');
-                                  if (reason) suspendUser(user._id, reason);
-                                }}
-                              >
-                                Suspend
-                              </button>
-                            )}
+                            <div className="action-buttons">
+                              {user.isSuspended ? (
+                                <button
+                                  className="action-btn unsuspend"
+                                  onClick={() => unsuspendUser(user._id)}
+                                >
+                                  Unsuspend
+                                </button>
+                              ) : (
+                                <button
+                                  className="action-btn suspend"
+                                  onClick={() => {
+                                    const reason = prompt('Reason for suspension:');
+                                    if (reason) suspendUser(user._id, reason);
+                                  }}
+                                >
+                                  Suspend
+                                </button>
+                              )}
+                              {user.isAdminPromoted ? (
+                                <button
+                                  className="action-btn demote"
+                                  onClick={() => demoteUser(user._id)}
+                                >
+                                  Remove Admin
+                                </button>
+                              ) : (
+                                <button
+                                  className="action-btn promote"
+                                  onClick={() => promoteUser(user._id)}
+                                >
+                                  Make Admin
+                                </button>
+                              )}
+                            </div>
                           </td>
                         </tr>
                       ))}

--- a/client/src/components/Auth/Auth.css
+++ b/client/src/components/Auth/Auth.css
@@ -365,3 +365,40 @@
     animation: none;
   }
 }
+
+.account-type-selection {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-top: 8px;
+}
+
+.radio-option {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px;
+  border: 2px solid var(--color-border);
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.radio-option:hover {
+  border-color: var(--color-primary);
+  background-color: var(--color-bg-secondary);
+}
+
+.radio-option input[type="radio"] {
+  margin: 0;
+}
+
+.radio-option input[type="radio"]:checked + span {
+  font-weight: 600;
+  color: var(--color-primary);
+}
+
+.radio-option:has(input[type="radio"]:checked) {
+  border-color: var(--color-primary);
+  background-color: rgba(102, 126, 234, 0.1);
+}

--- a/client/src/components/Auth/Register.js
+++ b/client/src/components/Auth/Register.js
@@ -9,7 +9,8 @@ const Register = () => {
     password: '',
     confirmPassword: '',
     firstName: '',
-    lastName: ''
+    lastName: '',
+    accountType: 'both'
   });
   const [error, setError] = useState('');
   const [success, setSuccess] = useState('');
@@ -176,6 +177,42 @@ const Register = () => {
               >
                 {showConfirmPassword ? '👁️' : '👁️‍🗨️'}
               </button>
+            </div>
+          </div>
+
+          <div className="form-group">
+            <label className="form-label">I want to:</label>
+            <div className="account-type-selection">
+              <label className="radio-option">
+                <input
+                  type="radio"
+                  name="accountType"
+                  value="freelancer"
+                  checked={formData.accountType === 'freelancer'}
+                  onChange={handleChange}
+                />
+                <span>Work as a freelancer</span>
+              </label>
+              <label className="radio-option">
+                <input
+                  type="radio"
+                  name="accountType"
+                  value="client"
+                  checked={formData.accountType === 'client'}
+                  onChange={handleChange}
+                />
+                <span>Hire freelancers</span>
+              </label>
+              <label className="radio-option">
+                <input
+                  type="radio"
+                  name="accountType"
+                  value="both"
+                  checked={formData.accountType === 'both'}
+                  onChange={handleChange}
+                />
+                <span>Both</span>
+              </label>
             </div>
           </div>
 

--- a/client/src/components/Navigation/Navigation.js
+++ b/client/src/components/Navigation/Navigation.js
@@ -38,7 +38,7 @@ const Navigation = () => {
         </Link>
       </div>
       
-      {isAuthenticated && user?.role === 'freelancer' && (
+      {isAuthenticated && (user?.accountType === 'freelancer' || user?.accountType === 'both') && (
         <div className="role-switcher">
           <span className="role-label">Viewing as:</span>
           <div className="role-toggle">
@@ -48,12 +48,14 @@ const Navigation = () => {
             >
               Freelancer
             </button>
-            <button 
-              className={`role-btn ${currentRole === 'client' ? 'active' : ''}`}
-              onClick={() => handleRoleSwitch('client')}
-            >
-              Client
-            </button>
+            {(user?.accountType === 'both' || user?.accountType === 'client') && (
+              <button 
+                className={`role-btn ${currentRole === 'client' ? 'active' : ''}`}
+                onClick={() => handleRoleSwitch('client')}
+              >
+                Client
+              </button>
+            )}
           </div>
         </div>
       )}

--- a/server/middleware/validation.js
+++ b/server/middleware/validation.js
@@ -36,6 +36,10 @@ const validateRegister = [
     .trim()
     .isLength({ min: 1, max: 50 })
     .withMessage('Last name is required and cannot exceed 50 characters'),
+  body('accountType')
+    .optional()
+    .isIn(['client', 'freelancer', 'both'])
+    .withMessage('Account type must be client, freelancer, or both'),
   handleValidationErrors
 ];
 

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -141,7 +141,11 @@ const userSchema = new mongoose.Schema({
     type: String,
     enum: ['local', 'google', 'facebook'],
     default: 'local'
-  }]
+  }],
+  isAdminPromoted: {
+    type: Boolean,
+    default: false
+  }
 }, {
   timestamps: true
 });

--- a/server/routes/admin.js
+++ b/server/routes/admin.js
@@ -634,4 +634,58 @@ router.get('/monitoring', authenticateAdmin, async (req, res) => {
   }
 });
 
+router.put('/users/:userId/promote', authenticateAdmin, requirePermission('user_management'), validateUserIdParam, async (req, res) => {
+  try {
+    const { userId } = req.params;
+    
+    const user = await User.findById(userId);
+    if (!user) {
+      return res.status(404).json({ error: 'User not found' });
+    }
+    
+    const ADMIN_EMAILS = process.env.ADMIN_EMAILS ? process.env.ADMIN_EMAILS.split(',') : ['stancp327@gmail.com'];
+    if (ADMIN_EMAILS.includes(user.email)) {
+      return res.status(400).json({ error: 'User is already an admin' });
+    }
+    
+    user.isAdminPromoted = true;
+    await user.save();
+    
+    res.json({
+      message: 'User promoted to admin successfully',
+      user: user.getPublicProfile()
+    });
+  } catch (error) {
+    console.error('Admin promote user error:', error);
+    res.status(500).json({ error: 'Failed to promote user' });
+  }
+});
+
+router.put('/users/:userId/demote', authenticateAdmin, requirePermission('user_management'), validateUserIdParam, async (req, res) => {
+  try {
+    const { userId } = req.params;
+    
+    const user = await User.findById(userId);
+    if (!user) {
+      return res.status(404).json({ error: 'User not found' });
+    }
+    
+    const ADMIN_EMAILS = process.env.ADMIN_EMAILS ? process.env.ADMIN_EMAILS.split(',') : ['stancp327@gmail.com'];
+    if (ADMIN_EMAILS.includes(user.email)) {
+      return res.status(400).json({ error: 'Cannot demote hardcoded admin user' });
+    }
+    
+    user.isAdminPromoted = false;
+    await user.save();
+    
+    res.json({
+      message: 'User demoted from admin successfully',
+      user: user.getPublicProfile()
+    });
+  } catch (error) {
+    console.error('Admin demote user error:', error);
+    res.status(500).json({ error: 'Failed to demote user' });
+  }
+});
+
 module.exports = router;


### PR DESCRIPTION
# feat: Add user type selection to registration and admin permission management

## Summary

This PR implements two key missing features:

1. **User Type Selection in Registration**: Adds radio buttons to the registration form allowing users to select their account type (client, freelancer, or both). The selected type determines which UI elements and functionality they see.

2. **Admin Permission Management**: Adds the ability for existing admins to promote regular users to admin status or demote promoted admins through the admin dashboard.

### Key Changes:
- **Frontend**: Enhanced registration form with account type selection UI, updated admin dashboard with promote/demote buttons, modified navigation to show role switcher based on account type
- **Backend**: Updated registration endpoint to handle `accountType`, added promote/demote API endpoints, enhanced admin detection logic to include promoted users
- **Database**: Added `isAdminPromoted` field to User model for tracking promoted admins

## Review & Testing Checklist for Human

**🔴 Critical - Must Test Before Merge:**
- [ ] **Admin promotion/demotion functionality**: Test promoting a regular user to admin and verify they can access admin dashboard, then test demoting them back
- [ ] **Registration with account types**: Register new users with each account type (client, freelancer, both) and verify the selection is saved correctly in the database
- [ ] **Role switching behavior**: Test that users with different `accountType` values see the correct role switcher options in navigation (freelancer-only users shouldn't see client options, etc.)
- [ ] **Backward compatibility**: Verify existing users without `accountType` set can still log in and function normally
- [ ] **Admin access consistency**: Verify that promoted admins have admin access across all admin endpoints, not just the dashboard

**⚠️ Important:**
- [ ] Test that hardcoded admins (from ADMIN_EMAILS) cannot be demoted through the UI
- [ ] Verify account type validation works correctly (rejects invalid values, handles missing values)

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
flowchart TD
    Register["client/src/components/Auth/<br/>Register.js"]:::major-edit
    AuthCSS["client/src/components/Auth/<br/>Auth.css"]:::minor-edit
    AdminDash["client/src/components/Admin/<br/>AdminDashboard.js"]:::major-edit
    AdminCSS["client/src/components/Admin/<br/>AdminDashboard.css"]:::minor-edit
    Navigation["client/src/components/Navigation/<br/>Navigation.js"]:::major-edit
    
    ServerIndex["server/index.js"]:::major-edit
    UserModel["server/models/User.js"]:::minor-edit
    AdminRoutes["server/routes/admin.js"]:::major-edit
    Validation["server/middleware/<br/>validation.js"]:::major-edit
    
    Register -->|"sends accountType"| ServerIndex
    AdminDash -->|"promote/demote API calls"| AdminRoutes
    Navigation -->|"reads user.accountType"| UserModel
    ServerIndex -->|"validates input"| Validation
    AdminRoutes -->|"updates isAdminPromoted"| UserModel
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit
        L3[Context/No Edit]:::context
    end
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

- **Testing Gap**: I was unable to fully test the admin promotion/demotion functionality locally due to authentication issues, so this requires thorough manual testing
- **Architecture Note**: The existing `RoleContext` (for UI role switching) and new `accountType` field serve different purposes and work together - `accountType` determines what roles a user *can* switch to, while `RoleContext` tracks what role they're *currently* viewing as
- **Backward Compatibility**: Existing users without `accountType` will default to 'both', maintaining current functionality
- **Security**: Hardcoded admins (from `ADMIN_EMAILS` env var) cannot be demoted, only promoted admins can be demoted

**Link to Devin run**: https://app.devin.ai/sessions/6a6cef1b7704403291a21615d6cda134  
**Requested by**: Chaz (@stancp327)