### PR TITLE
fix: Resolve SSL certificate issue for fetchwork.net domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ After resolving critical authentication and routing issues, the FetchWork platfo
 - **Current Production**: `fetchwork-temp.vercel.app` (fully functional)
 - **Custom Domain**: `fetchwork.net` (pending Vercel Pro Trial resolution - support ticket submitted)
 - **DNS Configuration**: ✅ Configured in Namecheap, awaiting Vercel domain binding approval
+- **SSL Certificate Issue**: ⚠️ Certificate only covers www.fetchwork.net, not root domain (see SSL_CERTIFICATE_ANALYSIS.md)
 
 **📊 Platform Ready For:**
 - ✅ Beta user onboarding and testing
@@ -574,6 +575,7 @@ npm run server  # Express backend on :10000
 ### Production Frontend (Vercel)
 - **Primary**: fetchwork-temp.vercel.app (CURRENT PRODUCTION)
 - **Custom Domain**: fetchwork.net (pending Vercel support resolution)
+- **SSL Status**: ⚠️ Certificate covers www.fetchwork.net only, not root domain
 - **Preview**: Automatic preview deployments for PRs
 - **Configuration**: vercel.json with Render backend integration
 
@@ -757,6 +759,12 @@ npm run server  # Express backend on :10000
 - **Symptoms**: Build fails with OpenSSL legacy provider errors
 - **Solution**: Use `NODE_OPTIONS="--openssl-legacy-provider" npm run build`
 - **Note**: This is automatically configured in the project
+
+**SSL Certificate Configuration Issues**
+- **Symptoms**: "This Connection Is Not Private" warning on https://fetchwork.net
+- **Root Cause**: SSL certificate only covers www.fetchwork.net, not root domain
+- **Solution**: Ensure both fetchwork.net and www.fetchwork.net are added as domains in Vercel project
+- **Documentation**: See SSL_CERTIFICATE_ANALYSIS.md for detailed resolution steps
 
 **Frontend Build Issues**
 - Run `npm install` in both client and server directories

--- a/SSL_CERTIFICATE_ANALYSIS.md
+++ b/SSL_CERTIFICATE_ANALYSIS.md
@@ -1,0 +1,111 @@
+# SSL Certificate Issue Analysis for FetchWork
+
+## Problem Description
+- **Issue**: https://fetchwork.net shows "This Connection Is Not Private" warning
+- **Working**: https://www.fetchwork.net works correctly with HTTPS
+- **Root Cause**: SSL certificate only covers www.fetchwork.net, not the root domain fetchwork.net
+
+## Current Configuration Analysis
+
+### Vercel Configuration
+- Current vercel.json only contains rewrites and headers, no domain-specific configuration
+- No explicit domain configuration in project files
+
+### Domain Status (from README.md)
+- Current Production: fetchwork-temp.vercel.app (fully functional)
+- Custom Domain: fetchwork.net (pending Vercel Pro Trial resolution - support ticket submitted)
+- DNS Configuration: ✅ Configured in Namecheap, awaiting Vercel domain binding approval
+
+## Vercel SSL Certificate Behavior
+Based on Vercel documentation:
+1. SSL certificates are automatically provisioned using LetsEncrypt
+2. When adding an apex domain (fetchwork.net), Vercel should prompt to also add www subdomain
+3. Both domains should receive SSL certificates automatically
+4. The issue suggests only www.fetchwork.net was properly configured
+
+## Potential Solutions
+
+### Option 1: Vercel Dashboard Configuration (REQUIRED)
+- Ensure both fetchwork.net and www.fetchwork.net are added as domains in Vercel project
+- Verify DNS records point correctly to Vercel
+- Check if CAA records are blocking LetsEncrypt certificate generation
+
+### Option 2: DNS Configuration Verification
+- Verify A record for fetchwork.net points to correct Vercel IP (76.76.21.21)
+- Verify CNAME record for www.fetchwork.net points to cname.vercel-dns.com
+- Check for missing CAA records that allow LetsEncrypt
+
+### Option 3: Configuration File Updates (Limited Impact)
+- Add domain-specific configuration to vercel.json if supported
+- Ensure proper redirects between apex and www domains
+
+## Vercel Dashboard Steps Required
+
+### Step 1: Navigate to Domain Settings
+1. Go to Vercel dashboard
+2. Select the FetchWork project
+3. Navigate to Settings → Domains
+
+### Step 2: Verify Domain Configuration
+1. Check if both fetchwork.net and www.fetchwork.net are listed as domains
+2. Verify SSL certificate status for both domains
+3. Check if both domains show "Valid Configuration" status
+
+### Step 3: Add Missing Domain (if needed)
+1. If only www.fetchwork.net is configured, add fetchwork.net as a domain
+2. Vercel should automatically prompt to add both apex and www when adding one
+3. Wait for SSL certificate generation (can take up to 24 hours)
+
+### Step 4: DNS Verification
+1. Verify A record: fetchwork.net → 76.76.21.21
+2. Verify CNAME record: www.fetchwork.net → cname.vercel-dns.com
+3. Check for CAA records that might block LetsEncrypt
+
+## Expected DNS Configuration
+
+```
+Type    Name                Value
+A       fetchwork.net       76.76.21.21
+CNAME   www.fetchwork.net   cname.vercel-dns.com
+```
+
+## Troubleshooting Common Issues
+
+### Issue: SSL Certificate Not Generated for Apex Domain
+- **Cause**: Only www subdomain was added to Vercel project
+- **Solution**: Add both fetchwork.net and www.fetchwork.net as domains
+
+### Issue: CAA Records Blocking LetsEncrypt
+- **Cause**: DNS provider has CAA records that don't allow LetsEncrypt
+- **Solution**: Add CAA record: `0 issue "letsencrypt.org"`
+
+### Issue: DNS Propagation Delays
+- **Cause**: DNS changes can take up to 48 hours to propagate
+- **Solution**: Wait for propagation, use DNS checker tools
+
+## Verification Steps
+
+### After Configuration Changes:
+1. Test https://fetchwork.net (should work without SSL warnings)
+2. Test https://www.fetchwork.net (should continue working)
+3. Verify SSL certificates are properly generated for both domains
+4. Check that redirects work correctly between apex and www domains
+5. Ensure all existing functionality continues to work
+
+### Tools for Verification:
+- SSL Labs SSL Test: https://www.ssllabs.com/ssltest/
+- DNS Checker: https://dnschecker.org/
+- Vercel domain status in dashboard
+
+## Next Steps for Implementation
+
+1. **Immediate**: Document the issue and required Vercel dashboard changes
+2. **User Action Required**: Access Vercel dashboard to verify/add both domains
+3. **Verification**: Test both URLs after configuration changes
+4. **Monitoring**: Check SSL certificate status and renewal
+
+## Expected Outcome
+Both https://fetchwork.net and https://www.fetchwork.net should work without SSL warnings after proper Vercel domain configuration.
+
+## Limitations
+This fix requires Vercel dashboard access to verify and modify domain configuration, which cannot be done through code changes alone. The analysis and guidance provided should enable resolution through the Vercel dashboard.

--- a/VERCEL_DOMAIN_CONFIGURATION_GUIDE.md
+++ b/VERCEL_DOMAIN_CONFIGURATION_GUIDE.md
@@ -1,0 +1,83 @@
+# Vercel Domain Configuration Guide for FetchWork
+
+## SSL Certificate Issue Resolution
+
+### Problem
+- https://fetchwork.net shows "This Connection Is Not Private" warning
+- https://www.fetchwork.net works correctly
+- SSL certificate only covers www subdomain, not root domain
+
+### Required Actions in Vercel Dashboard
+
+#### Step 1: Access Domain Settings
+1. Log into Vercel dashboard
+2. Navigate to FetchWork project
+3. Go to Settings → Domains
+
+#### Step 2: Verify Current Configuration
+Check if both domains are properly configured:
+- ✅ www.fetchwork.net (currently working)
+- ❌ fetchwork.net (needs SSL certificate)
+
+#### Step 3: Add Root Domain (if missing)
+1. Click "Add Domain"
+2. Enter: `fetchwork.net`
+3. Vercel should automatically suggest adding both apex and www
+4. Confirm both domains are added
+
+#### Step 4: Verify DNS Configuration
+Ensure DNS records in Namecheap match Vercel requirements:
+
+```
+Type    Name                Value                    TTL
+A       fetchwork.net       76.76.21.21             Auto
+CNAME   www.fetchwork.net   cname.vercel-dns.com    Auto
+```
+
+#### Step 5: SSL Certificate Generation
+- Vercel automatically provisions SSL certificates via LetsEncrypt
+- Process can take up to 24 hours
+- Both domains should show "Valid Configuration" status
+
+### Troubleshooting
+
+#### If SSL Certificate Fails to Generate:
+1. **Check CAA Records**: Ensure no CAA records block LetsEncrypt
+2. **DNS Propagation**: Wait up to 48 hours for DNS changes
+3. **Domain Verification**: Ensure domain ownership is verified
+
+#### Required CAA Record (if needed):
+```
+Type    Name                Value
+CAA     fetchwork.net       0 issue "letsencrypt.org"
+```
+
+### Verification Steps
+
+#### After Configuration:
+1. Test https://fetchwork.net (should work without warnings)
+2. Test https://www.fetchwork.net (should continue working)
+3. Verify SSL certificate covers both domains
+4. Check redirect behavior between domains
+
+#### Tools for Testing:
+- SSL Labs: https://www.ssllabs.com/ssltest/
+- DNS Checker: https://dnschecker.org/
+- Browser developer tools for certificate inspection
+
+### Expected Timeline
+- **Immediate**: Domain addition in Vercel dashboard
+- **1-24 hours**: SSL certificate generation
+- **24-48 hours**: Full DNS propagation
+
+### Success Criteria
+- ✅ https://fetchwork.net works without SSL warnings
+- ✅ https://www.fetchwork.net continues working
+- ✅ Both domains show valid SSL certificates
+- ✅ Proper redirects between apex and www domains
+
+### Notes
+- This configuration requires Vercel dashboard access
+- No code changes needed in the project
+- DNS configuration in Namecheap should already be correct
+- Issue is specifically with Vercel domain binding, not DNS

--- a/client/vercel.json
+++ b/client/vercel.json
@@ -10,5 +10,18 @@
         { "key": "Content-Type", "value": "application/manifest+json" }
       ]
     }
+  ],
+  "redirects": [
+    {
+      "source": "/(.*)",
+      "has": [
+        {
+          "type": "host",
+          "value": "fetchwork.net"
+        }
+      ],
+      "destination": "https://www.fetchwork.net/$1",
+      "permanent": true
+    }
   ]
 }


### PR DESCRIPTION
# fix: Resolve SSL certificate issue for fetchwork.net domain

## Summary

This PR addresses the SSL certificate issue where `https://fetchwork.net` shows "This Connection Is Not Private" warnings while `https://www.fetchwork.net` works correctly. The root cause is that the SSL certificate only covers the www subdomain, not the apex domain.

**Key Changes:**
- **Documentation**: Created comprehensive analysis and step-by-step Vercel configuration guide
- **Temporary Workaround**: Added redirect from `fetchwork.net` to `www.fetchwork.net` in vercel.json
- **Project Updates**: Updated README.md with SSL status and troubleshooting information

**Important**: The core fix requires manual Vercel dashboard configuration to add both domains - this cannot be automated through code changes.

## Review & Testing Checklist for Human

- [ ] **CRITICAL**: Follow `VERCEL_DOMAIN_CONFIGURATION_GUIDE.md` to add both `fetchwork.net` and `www.fetchwork.net` as domains in Vercel dashboard
- [ ] **Test SSL behavior**: Verify if the vercel.json redirect helps users avoid SSL warnings (it may not work for initial SSL handshake)
- [ ] **Verify documentation accuracy**: Check that Vercel dashboard steps match current interface
- [ ] **End-to-end testing**: After Vercel configuration, test both `https://fetchwork.net` and `https://www.fetchwork.net` for SSL warnings
- [ ] **DNS verification**: Confirm DNS records match requirements (A record: 76.76.21.21, CNAME: cname.vercel-dns.com)

**Test Plan**: 
1. First test current behavior with SSL warnings
2. Apply Vercel dashboard changes per guide
3. Wait for SSL certificate generation (up to 24 hours)  
4. Test both URLs for SSL certificate coverage
5. Verify redirect behavior works as expected

---

### Diagram
```mermaid
%%{ init : { "theme" : "default" }}%%
graph TB
    subgraph "SSL Certificate Fix"
        SSLAnalysis["SSL_CERTIFICATE_ANALYSIS.md<br/>Root cause analysis"]:::major-edit
        VercelGuide["VERCEL_DOMAIN_CONFIGURATION_GUIDE.md<br/>Step-by-step fix"]:::major-edit
        README["README.md<br/>Updated status"]:::minor-edit
        VercelJSON["client/vercel.json<br/>Added redirect"]:::minor-edit
    end
    
    subgraph "Problem"
        FetchworkNet["fetchwork.net<br/>SSL Warning"]:::context
        WWWFetchwork["www.fetchwork.net<br/>Works correctly"]:::context
    end
    
    subgraph "Solution Required"
        VercelDashboard["Vercel Dashboard<br/>Add both domains"]:::context
        DNSConfig["DNS Configuration<br/>Namecheap"]:::context
    end
    
    SSLAnalysis --> VercelGuide
    VercelGuide --> VercelDashboard
    VercelJSON --> FetchworkNet
    FetchworkNet -.-> WWWFetchwork
    VercelDashboard --> DNSConfig
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

**Limitations**: This PR provides comprehensive documentation and a potential workaround, but the actual SSL certificate fix requires manual Vercel dashboard access to add both `fetchwork.net` and `www.fetchwork.net` as domains. The redirect in vercel.json may not resolve SSL warnings since they occur during the initial TLS handshake.

**Timeline**: After Vercel configuration, SSL certificate generation can take up to 24 hours, and DNS propagation may take up to 48 hours.

Link to Devin run: https://app.devin.ai/sessions/6a6cef1b7704403291a21615d6cda134  
Requested by: Chaz (@stancp327)