### PR TITLE
Fix admin authentication error and prevent AuthErrorBoundary triggers

### DIFF
--- a/client/src/components/Admin/AdminDashboard.js
+++ b/client/src/components/Admin/AdminDashboard.js
@@ -35,6 +35,8 @@ const AdminDashboard = () => {
 
   useEffect(() => {
     if (!isAdminAuthenticated) {
+      setError('Admin access required. Please contact support if you believe this is an error.');
+      setLoading(false);
     }
   }, [isAdminAuthenticated]);
 
@@ -44,12 +46,10 @@ const AdminDashboard = () => {
       setError('');
       const token = localStorage.getItem('token');
       
-      console.log('Fetching admin dashboard data...');
-      console.log('API Base URL:', apiBaseUrl);
-      console.log('Token:', token ? 'Present' : 'Missing');
-      
       if (!token) {
-        throw new Error('No authentication token found');
+        setError('Authentication token not found. Please log in again.');
+        setLoading(false);
+        return;
       }
       
       const response = await axios.get(`${apiBaseUrl}/api/admin/dashboard`, {
@@ -58,19 +58,14 @@ const AdminDashboard = () => {
         }
       });
       
-      console.log('Admin dashboard API response:', response.data);
-      console.log('Stats data:', response.data.stats);
-      console.log('Recent activity data:', response.data.recentActivity);
-      
       setDashboardData(response.data);
       setError(null);
     } catch (error) {
-      console.error('Failed to fetch dashboard data:', error);
-      console.error('Error response:', error.response?.data);
+      console.error('AdminDashboard fetch error:', error);
       if (error.response?.status === 401) {
         setError('Authentication failed - please log in again');
       } else {
-        setError(error.response?.data?.error || 'Failed to load dashboard data');
+        setError('Unable to load dashboard data. Please try again later.');
       }
     } finally {
       setLoading(false);
@@ -153,28 +148,44 @@ const AdminDashboard = () => {
 
   useEffect(() => {
     if (isAdminAuthenticated) {
-      fetchDashboardData();
+      fetchDashboardData().catch(error => {
+        console.error('Failed to fetch dashboard data on mount:', error);
+      });
     }
   }, [isAdminAuthenticated, fetchDashboardData]);
 
   useEffect(() => {
     if (activeTab === 'users' && isAdminAuthenticated) {
-      fetchUsersData();
+      fetchUsersData().catch(error => {
+        console.error('Failed to fetch users data:', error);
+      });
     } else if (activeTab === 'jobs' && isAdminAuthenticated) {
-      fetchJobsData();
+      fetchJobsData().catch(error => {
+        console.error('Failed to fetch jobs data:', error);
+      });
     } else if (activeTab === 'payments' && isAdminAuthenticated) {
-      fetchPaymentsData();
+      fetchPaymentsData().catch(error => {
+        console.error('Failed to fetch payments data:', error);
+      });
     } else if (activeTab === 'reviews' && isAdminAuthenticated) {
-      fetchReviewsData();
+      fetchReviewsData().catch(error => {
+        console.error('Failed to fetch reviews data:', error);
+      });
     } else if (activeTab === 'monitoring' && isAdminAuthenticated) {
-      fetchMonitoringData();
+      fetchMonitoringData().catch(error => {
+        console.error('Failed to fetch monitoring data:', error);
+      });
     }
   }, [activeTab, isAdminAuthenticated, fetchUsersData, fetchJobsData, fetchPaymentsData, fetchReviewsData, fetchMonitoringData]);
 
   useEffect(() => {
     let interval;
     if (activeTab === 'monitoring' && autoRefresh && isAdminAuthenticated) {
-      interval = setInterval(fetchMonitoringData, 30000);
+      interval = setInterval(() => {
+        fetchMonitoringData().catch(error => {
+          console.error('Failed to fetch monitoring data on interval:', error);
+        });
+      }, 30000);
     }
     return () => {
       if (interval) clearInterval(interval);


### PR DESCRIPTION
# Fix admin authentication error and prevent AuthErrorBoundary triggers

## Summary

Resolves the critical bug where users encountered an "Authentication Error" when trying to access the admin page at `/admin`. The issue was caused by unhandled promise rejections in the AdminDashboard component that bubbled up to trigger the AuthErrorBoundary, preventing admin users from accessing the dashboard.

**Key Changes:**
- **Fixed unhandled promise rejections** in AdminDashboard useEffect hooks by adding `.catch()` handlers
- **Replaced thrown errors with graceful error states** - removed `throw new Error()` calls that triggered AuthErrorBoundary
- **Improved error messages** for better user experience (e.g., "Unable to load dashboard data" instead of generic authentication errors)
- **Added proper admin access validation** with user-friendly error messages
- **Cleaned up debugging console.log statements** added during investigation

## Review & Testing Checklist for Human

⚠️ **High Priority - End-to-End Testing Required** (I was unable to fully test due to missing backend environment variables)

- [ ] **Login as admin user and navigate to `/admin`** - should load dashboard without AuthErrorBoundary
- [ ] **Test non-admin user access to `/admin`** - should show "Admin access required" message, not crash
- [ ] **Test with expired/invalid JWT token** - should show authentication error message, not trigger AuthErrorBoundary  
- [ ] **Test with backend server down** - should show "Unable to load dashboard data" message gracefully
- [ ] **Verify browser console shows no unhandled promise rejection errors** when navigating to admin page

**Recommended Test Plan:**
1. Start backend server with proper environment variables
2. Login with admin credentials (`stancp327@gmail.com`) 
3. Navigate to `/admin` and verify dashboard loads successfully
4. Test error scenarios (logout, expired token, network issues)
5. Test with non-admin user account

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    User[User navigates to /admin]
    App["App.js<br/>AuthErrorBoundary"]:::context
    AuthContext["AuthContext.js<br/>user.isAdmin check"]:::context
    AdminDashboard["AdminDashboard.js<br/>Main component"]:::major-edit
    
    User --> App
    App --> AuthContext
    AuthContext --> AdminDashboard
    
    AdminDashboard --> UseEffect1["useEffect()<br/>fetchDashboardData()"]:::major-edit
    AdminDashboard --> UseEffect2["useEffect()<br/>tab data fetching"]:::major-edit
    
    UseEffect1 --> TokenCheck["Token validation<br/>graceful error handling"]:::major-edit
    UseEffect2 --> CatchHandlers[".catch() handlers<br/>prevent unhandled rejections"]:::major-edit
    
    TokenCheck --> ErrorState["setError() instead of<br/>throw new Error()"]:::major-edit
    CatchHandlers --> ConsoleLog["console.error()<br/>for debugging"]:::minor-edit
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

**Root Cause:** The AdminDashboard component's useEffect hooks were calling async functions (`fetchDashboardData`, etc.) without proper error handling. When these functions threw errors (like "No authentication token found"), they became unhandled promise rejections that bubbled up to the AuthErrorBoundary, causing the generic "Authentication Error" screen.

**Solution:** Wrapped all async calls in useEffect hooks with `.catch()` handlers and replaced `throw new Error()` statements with graceful error state management using `setError()` and `setLoading()`.

**Testing Limitation:** Unable to perform full end-to-end testing due to missing backend environment variables (MONGO_URI, JWT_SECRET, etc.) in the development environment. Human testing with proper backend setup is critical.

---

Link to Devin run: https://app.devin.ai/sessions/15ea4a99b4ca40b09fbe31cebaa2e159  
Requested by: Chaz (@stancp327)