### PR TITLE
Auth hardening: req.user stabilization, OAuth URL unification, provider dedupe, bcrypt 14, and hybrid role prep

### DIFF
--- a/README.md
+++ b/README.md
@@ -938,6 +938,17 @@ For issues or questions:
 
 ---
 
+## Authentication updates (2025-08-13)
+- Standardized on req.user._id in backend; added a temporary compatibility shim that also sets req.user.userId.
+- OAuth start URLs on the client now use getApiBaseUrl() for environment consistency.
+- Prevent duplicate entries in the providers array when linking Google/Facebook.
+- Increased bcrypt salt rounds from 12 to 14 for stronger password hashing.
+- Introduced a role field on User ('user' | 'admin'), with hybrid admin detection:
+  - Admins are recognized if role === 'admin', email is in ADMIN_EMAILS, or isAdminPromoted is true.
+  - JWT now includes role alongside isAdmin for compatibility.
+Future work: migrate admin checks fully to role and deprecate ADMIN_EMAILS/isAdminPromoted after backfill.
+
+
 **Last Updated**: January 22, 2025  
 **Version**: 2.0.0 (AdminDashboard Restoration Complete)  
 **Maintainer**: Chaz (@stancp327)  

--- a/client/src/components/Auth/Login.js
+++ b/client/src/components/Auth/Login.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { Link, useNavigate, useLocation } from 'react-router-dom';
 import { useAuth } from '../../context/AuthContext';
 import './Auth.css';
+import { getApiBaseUrl } from '../../utils/api';
 
 const Login = () => {
   const [email, setEmail] = useState('');
@@ -41,11 +42,11 @@ const Login = () => {
   };
 
   const handleGoogleLogin = () => {
-    window.location.href = `${process.env.REACT_APP_API_URL}/api/auth/google`;
+    window.location.href = `${getApiBaseUrl()}/api/auth/google`;
   };
 
   const handleFacebookLogin = () => {
-    window.location.href = `${process.env.REACT_APP_API_URL}/api/auth/facebook`;
+    window.location.href = `${getApiBaseUrl()}/api/auth/facebook`;
   };
 
   return (

--- a/client/src/components/Auth/Register.js
+++ b/client/src/components/Auth/Register.js
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { useAuth } from '../../context/AuthContext';
 import './Auth.css';
+import { getApiBaseUrl } from '../../utils/api';
 
 const Register = () => {
   const [formData, setFormData] = useState({
@@ -67,11 +68,11 @@ const Register = () => {
   };
 
   const handleGoogleLogin = () => {
-    window.location.href = `${process.env.REACT_APP_API_URL}/api/auth/google`;
+    window.location.href = `${getApiBaseUrl()}/api/auth/google`;
   };
 
   const handleFacebookLogin = () => {
-    window.location.href = `${process.env.REACT_APP_API_URL}/api/auth/facebook`;
+    window.location.href = `${getApiBaseUrl()}/api/auth/facebook`;
   };
 
   return (

--- a/server/middleware/auth.js
+++ b/server/middleware/auth.js
@@ -23,6 +23,9 @@ const authenticateToken = async (req, res, next) => {
     }
     
     req.user = user;
+    if (!req.user.userId) {
+      req.user.userId = user._id.toString();
+    }
     next();
   } catch (error) {
     if (error.name === 'TokenExpiredError') {
@@ -47,7 +50,7 @@ const authenticateAdmin = async (req, res, next) => {
     
     const decoded = jwt.verify(token, process.env.JWT_SECRET);
     
-    if (!decoded.isAdmin) {
+    if (!(decoded.isAdmin || decoded.role === 'admin')) {
       return res.status(401).json({ error: 'Admin access required' });
     }
     
@@ -121,6 +124,9 @@ const optionalAuth = async (req, res, next) => {
     
     if (user && !user.isSuspended) {
       req.user = user;
+      if (!req.user.userId) {
+        req.user.userId = user._id.toString();
+      }
     } else {
       req.user = null;
     }

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -147,6 +147,11 @@ const userSchema = new mongoose.Schema({
   isAdminPromoted: {
     type: Boolean,
     default: false
+  },
+  role: {
+    type: String,
+    enum: ['user', 'admin'],
+    default: 'user'
   }
 }, {
   timestamps: true
@@ -163,7 +168,7 @@ userSchema.pre('save', async function(next) {
   if (!this.isModified('password')) return next();
   
   try {
-    const salt = await bcrypt.genSalt(12);
+    const salt = await bcrypt.genSalt(14);
     this.password = await bcrypt.hash(this.password, salt);
     next();
   } catch (error) {


### PR DESCRIPTION
# Auth hardening: req.user stabilization, OAuth URL unification, provider dedupe, bcrypt 14, and hybrid role prep

## Summary

This PR implements comprehensive authentication system improvements addressing inconsistencies and security vulnerabilities identified in the codebase audit:

**P0 - Critical Fixes:**
- **Stabilized req.user interface**: Added backward compatibility shim (`req.user.userId = user._id.toString()`) in auth middleware to prevent errors in routes expecting `userId` while standardizing on `_id`
- **Fixed /api/auth/me endpoint**: Now correctly uses `req.user._id` instead of the non-existent `req.user.userId`

**P1 - OAuth Consistency:**
- **Unified OAuth start URLs**: Frontend auth components now use centralized `getApiBaseUrl()` instead of direct `REACT_APP_API_URL` for environment consistency
- **OAuth provider deduplication**: Prevent duplicate entries in user.providers array during account linking

**P2 - Security Enhancements:**
- **Increased bcrypt rounds**: Bumped from 12 to 14 rounds for stronger password hashing
- **Future-proofed admin system**: Added `role` field to User schema with hybrid admin detection logic

**P3 - Documentation:**
- Added comprehensive changelog documenting all authentication changes and future migration plans

## Review & Testing Checklist for Human

⚠️ **HIGH RISK CHANGES** - Please test thoroughly:

- [ ] **Basic auth flows work**: Test login, registration, and logout functionality
- [ ] **OAuth flows functional**: Verify Google and Facebook OAuth still work correctly (URLs and callbacks)
- [ ] **Admin access preserved**: Confirm existing admins can still access admin routes and new role field doesn't break anything
- [ ] **Existing users unaffected**: Login with existing user accounts to ensure backward compatibility
- [ ] **API endpoint verification**: Test `/api/auth/me` returns correct user data without errors

**Recommended test plan:**
1. Register new user → login → access protected routes
2. Test Google OAuth login flow end-to-end  
3. Test Facebook OAuth login flow end-to-end
4. Login as existing admin → verify admin dashboard access
5. Check server logs for any authentication-related errors

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TB
    subgraph "Frontend Auth"
        Login["client/src/components/Auth/<br/>Login.js"]:::major-edit
        Register["client/src/components/Auth/<br/>Register.js"]:::major-edit
        ApiUtils["client/src/utils/api.js"]:::context
    end
    
    subgraph "Backend Auth Core"
        AuthMW["server/middleware/<br/>auth.js"]:::major-edit
        MainServer["server/index.js"]:::major-edit
        UserModel["server/models/<br/>User.js"]:::major-edit
    end
    
    subgraph "Documentation"
        README["README.md"]:::minor-edit
    end
    
    Login -->|"OAuth URLs now use<br/>getApiBaseUrl()"| ApiUtils
    Register -->|"OAuth URLs now use<br/>getApiBaseUrl()"| ApiUtils
    
    AuthMW -->|"req.user compatibility<br/>shim added"| MainServer
    MainServer -->|"Uses req.user._id<br/>includes role in JWT"| UserModel
    UserModel -->|"Added role field<br/>bcrypt rounds = 14"| AuthMW
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

**Key Implementation Details:**
- The `req.user.userId` compatibility shim ensures existing routes continue working while we standardize on `_id`
- JWT tokens now include both `isAdmin` (backward compatibility) and `role` (future-proofing)
- Admin detection uses hybrid logic: `role === 'admin' || ADMIN_EMAILS.includes(email) || isAdminPromoted`
- OAuth provider arrays are now properly deduplicated to prevent duplicate entries

**Future Work:**
- Migrate all routes to use `req.user._id` directly and remove compatibility shim
- Fully transition admin checks to use `role` field and deprecate `ADMIN_EMAILS`/`isAdminPromoted`

---

**Link to Devin run**: https://app.devin.ai/sessions/2be9d645e3af4075beca0bf2c8e8f4a1  
**Requested by**: Chaz (@stancp327)